### PR TITLE
Replace TopModel, which is abandoned, and add support for ActiveModel 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem "rspec"
 gem "factory_bot"
-gem "topmodel"
 gem "representable"
 gem "multi_json"
-gem "activemodel", "~> 4.2.6"
+gem "activemodel", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "rspec"
-gem "factory_girl"
+gem "factory_bot"
 gem "topmodel"
 gem "representable"
 gem "multi_json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
-      builder (~> 3.1)
-    activesupport (4.2.6)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
+    activemodel (6.0.3.3)
+      activesupport (= 6.0.3.3)
+    activesupport (6.0.3.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    builder (3.2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    concurrent-ruby (1.1.7)
     declarative (0.0.7)
       uber (>= 0.0.15)
     diff-lcs (1.2.5)
-    factory_girl (4.7.0)
-      activesupport (>= 3.0.0)
-    i18n (0.7.0)
-    json (1.8.3)
-    minitest (5.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.2)
     multi_json (1.12.1)
     representable (3.0.0)
       declarative (~> 0.0.5)
@@ -36,23 +35,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     topmodel (0.2.2)
       activemodel (>= 3.0.0)
-    tzinfo (1.2.2)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.0.15)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel (~> 4.2.6)
-  factory_girl
+  activemodel (~> 6.0)
+  factory_bot
   multi_json
   representable
   rspec
   topmodel
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ class FakeTwitterClient < Shoegaze::Mock
 
   mock "Twitter::Client"
 
-  # creates both a FakeTwitterClient::Update 'model' and a FactoryGirl
+  # creates both a FakeTwitterClient::Update 'model' and a FactoryBot
   # factory for the model
   datastore :Update do
     id{ BSON::ObjectId.new }
@@ -56,7 +56,7 @@ class FakeTwitterClient < Shoegaze::Mock
       datasource do
         # generate an update and store it in the memory store (you can
         # grab it with FakerTwitterClient::Update.find(update.id)
-        FactoryGirl.create(Update)
+        FactoryBot.create(Update)
       end
     end
 
@@ -76,7 +76,7 @@ class FakeTwitterClient < Shoegaze::Mock
         implement :create do
           # default scenarios can be specified
           default do |params|
-            FactoryGirl.create(Account, params)
+            FactoryBot.create(Account, params)
           end
         end
       end
@@ -181,7 +181,7 @@ rather than the real argument type.
 ## Generate test data randomly and dynamically rather than use fixtures
 
 Use Faker. Generate test data in the most flexible format. Generally
-that's a ruby object with accessors produced by Factory Girl, since
+that's a ruby object with accessors produced by Factory Bot, since
 it can easily be turned into a hash, JSON, or left as-is.
 
 ## Test the immediate layer of the component you're testing

--- a/lib/shoegaze.rb
+++ b/lib/shoegaze.rb
@@ -2,7 +2,7 @@ module Shoegaze
 end
 
 require 'rspec'
-require 'factory_girl'
+require 'factory_bot'
 require 'top_model'
 require 'representable'
 require 'multi_json'

--- a/lib/shoegaze.rb
+++ b/lib/shoegaze.rb
@@ -3,7 +3,6 @@ end
 
 require 'rspec'
 require 'factory_bot'
-require 'top_model'
 require 'representable'
 require 'multi_json'
 require 'representable/json'
@@ -13,3 +12,4 @@ require_relative 'shoegaze/implementation'
 require_relative 'shoegaze/proxy'
 require_relative 'shoegaze/mock'
 require_relative 'shoegaze/scenario'
+require_relative 'shoegaze/model'

--- a/lib/shoegaze/datastore.rb
+++ b/lib/shoegaze/datastore.rb
@@ -3,7 +3,7 @@ module Shoegaze
     # Defines both a TopModel-inherited class and a factory in the mock namespace
     #
     # @param name [Symbol] upcased name of the datastore to create (example: :User)
-    # @param block [Block] FactoryGirl factory implementation expressed in a block
+    # @param block [Block] FactoryBot factory implementation expressed in a block
     # @return [Class] the created datastore class
     #
     # example:
@@ -16,7 +16,7 @@ module Shoegaze
     def datastore(name, &block)
       klass = create_datastore_class(name)
 
-      FactoryGirl.define do
+      FactoryBot.define do
         factory klass do
           self.instance_eval(&block)
         end

--- a/lib/shoegaze/datastore.rb
+++ b/lib/shoegaze/datastore.rb
@@ -1,3 +1,5 @@
+require_relative "./model"
+
 module Shoegaze
   module Datastore
     # Defines both a TopModel-inherited class and a factory in the mock namespace
@@ -28,7 +30,7 @@ module Shoegaze
     private
 
     def create_datastore_class(name)
-      self.const_set(name, Class.new(TopModel::Base))
+      self.const_set(name, Class.new(Shoegaze::Model))
     end
   end
 end

--- a/lib/shoegaze/model.rb
+++ b/lib/shoegaze/model.rb
@@ -1,0 +1,165 @@
+require "active_model"
+
+class Shoegaze::Model
+  include ActiveModel::Model
+  include ActiveModel::Serializers::JSON
+
+  class UnknownRecordError < StandardError; end;
+
+  class << self
+    attr_writer :store
+
+    def drop_records
+      Shoegaze::Model.store = {}
+    end
+
+    def store
+      if self == Shoegaze::Model
+        @store ||= {}
+      else
+        Shoegaze::Model.store
+      end
+    end
+
+    def ensure_model_namespace(model)
+      # using an array here so that the models appear in the order they were created
+      store[model.class] ||= []
+    end
+
+    def register_model(model)
+      ensure_model_namespace(model)
+      store[model.class] << model
+      model
+    end
+
+    def unregister_model(model)
+      ensure_model_namespace(model)
+      store[model.class].delete(model)
+      model
+    end
+
+    def records_for_class(klass)
+      store[klass] || []
+    end
+
+    def where(options)
+      records_for_class(self).select do |r|
+        options.all? do |k, v|
+          if v.is_a?(Enumerable)
+            v.include?(r.send(k))
+          else
+            r.send(k) == v
+          end
+        end
+      end
+    end
+
+    def find_by(options)
+      where(options).first
+    end
+
+    def all
+      records_for_class(self)
+    end
+
+    def first
+      all[0]
+    end
+
+    def last
+      all[-1]
+    end
+
+    def raw_find(id) #:nodoc:
+      records_for_class(self).find { |r| r.id == id } ||
+        raise(UnknownRecordError, "Couldn't find #{self} with ID=#{id}")
+    end
+
+    def find(id)
+      raw_find(id)
+    end
+    alias :[] :find
+
+    def exists?(id)
+      raw_find(id) != nil
+    end
+
+    def count
+      records_for_class(self).length
+    end
+
+    def select(&block)
+      records_for_class(self).select(&block)
+    end
+
+    def create(attrs = {})
+      instance = self.new(attrs)
+      register_model(instance)
+    end
+
+    def update(id, atts)
+      find(id).update_attributes(atts)
+    end
+
+    def destroy(id)
+      find(id).destroy
+    end
+
+    def find_by_attribute(name, value) #:nodoc:
+      records_for_class(self).find {|r| r.send(name) == value }
+    end
+
+    def method_missing(method_symbol, *args) #:nodoc:
+      method_name = method_symbol.to_s
+
+      if method_name =~ /^find_by_(\w+)!/
+        send("find_by_#{$1}", *args) || raise(UnknownRecord)
+      elsif method_name =~ /^find_by_(\w+)/
+        find_by_attribute($1, args.first)
+      elsif method_name =~ /^find_or_create_by_(\w+)/
+        send("find_by_#{$1}", *args) || create($1 => args.first)
+      elsif method_name =~ /^find_all_by_(\w+)/
+        find_all_by_attribute($1, args.first)
+      else
+        super
+      end
+    end
+  end
+
+  attr_accessor :id
+
+  def initialize(attrs = {})
+    @id = SecureRandom.uuid
+    @__data = OpenStruct.new(attrs)
+  end
+
+  def save
+    Shoegaze::Model.register_model(self)
+  end
+  alias :save! :save
+
+  def destroy
+    Shoegaze::Model.unregister_model(self)
+  end
+  alias :destroy! :destroy
+
+  def update_attributes(attrs)
+    attrs.each do |k, v|
+      send("#{k}=", v)
+    end
+  end
+  alias :update_attributes! :update_attributes
+
+  def reload
+    self.class.find(id) || raise(Shoegaze::Model::UnknownRecordError)
+  end
+
+  def method_missing(method_symbol, *args) #:nodoc:
+    @__data.send(method_symbol, *args)
+  end
+
+  def as_json
+    @__data.to_h.with_indifferent_access
+  end
+  alias :attributes :as_json
+end

--- a/lib/shoegaze/version.rb
+++ b/lib/shoegaze/version.rb
@@ -1,3 +1,3 @@
 module Shoegaze
-  VERSION = "1.0.1".freeze
+  VERSION = "1.1.0".freeze
 end

--- a/shoegaze.gemspec
+++ b/shoegaze.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rspec"
   s.add_dependency "factory_bot"
-  s.add_dependency "topmodel"
   s.add_dependency "representable"
   s.add_dependency "multi_json"
 end

--- a/shoegaze.gemspec
+++ b/shoegaze.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "rspec"
-  s.add_dependency "factory_girl"
+  s.add_dependency "factory_bot"
   s.add_dependency "topmodel"
   s.add_dependency "representable"
   s.add_dependency "multi_json"

--- a/spec/features/data_store_spec.rb
+++ b/spec/features/data_store_spec.rb
@@ -41,7 +41,7 @@ class FakeDataStoreMethod < Shoegaze::Mock
       represent_method :as_json
 
       datasource do |sock_data|
-        FactoryBot.create(Sock, sock_data)
+        FactoryBot.create("fake_data_store_method/sock", sock_data)
       end
     end
   end

--- a/spec/features/data_store_spec.rb
+++ b/spec/features/data_store_spec.rb
@@ -41,7 +41,7 @@ class FakeDataStoreMethod < Shoegaze::Mock
       represent_method :as_json
 
       datasource do |sock_data|
-        FactoryGirl.create(Sock, sock_data)
+        FactoryBot.create(Sock, sock_data)
       end
     end
   end

--- a/spec/shoegaze/datastore_spec.rb
+++ b/spec/shoegaze/datastore_spec.rb
@@ -8,9 +8,9 @@ describe Shoegaze::Datastore do
     @klass.extend(Shoegaze::Datastore)
 
     @klass.datastore("Pony") do
-      id 123
-      hoofs 5
-      name "Jeff"
+      id { 123 }
+      hoofs { 5 }
+      name { "Jeff" }
     end
   end
 
@@ -19,7 +19,7 @@ describe Shoegaze::Datastore do
 
     describe "created model class" do
       it "creates a TopModel class with the specified name inside the class' namespace" do
-        expect(created_class.ancestors[1]).to eq TopModel::Base
+        expect(created_class.ancestors[1]).to eq Shoegaze::Model
       end
     end
 

--- a/spec/shoegaze/datastore_spec.rb
+++ b/spec/shoegaze/datastore_spec.rb
@@ -25,7 +25,7 @@ describe Shoegaze::Datastore do
 
     describe "factory" do
       let!(:model_instance) do
-        FactoryGirl.create(created_class.name.underscore, id: 5, name: "Carlos")
+        FactoryBot.create(created_class.name.underscore, id: 5, name: "Carlos")
       end
 
       it "creates persisted instances" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@ ENV['RAILS_ENV'] = 'test'
 
 require './lib/shoegaze'
 require 'rspec'
-require 'factory_girl'
+require 'factory_bot'
 
 Dir[File.expand_path('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
[TopModel](https://github.com/agilastic/topmodel) is long dead and doesn't seem to play with ActiveModel.

This PR removes the dependency and replaces it with Shoegaze's own in-memory data store: `Shoegaze::Model`.

Also included in this PR is changing from `FactoryGirl` to `FactoryBot` and bumping the `ActiveModel` dependency to version `6`.